### PR TITLE
ci: use the commit id for cuncurrency group

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -32,11 +32,10 @@ jobs:
       # Particularly useful for workflow triggered on release-plz sync.
       # release-plz workflow update de pending pr twice (with cargo readme update)
       # Note: Include commit message to not cancel job of commit not updated in push
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.commit.message }}
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.commit.id }}
       cancel-in-progress: true
     steps:
-      - name: "Checkout `${{ matrix.commit.message }}`"
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: "${{ matrix.commit.id }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Conventional Commits](https://www.conventionalcommits.o
 
 - add dependabot.yml with github-actions
 - update actions version
+- use the commit id for cuncurrency group
 
 ### ⚙️ Miscellaneous Tasks
 


### PR DESCRIPTION
This avoid problem with long commit msg in push workflow.
The concurrency group value is limited to 400 characters.